### PR TITLE
Live 30/changing get for event page

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -93,7 +93,7 @@
         {Credo.Check.Design.DuplicatedCode, false},
         {Credo.Check.Readability.AliasAs, false},
         {Credo.Check.Readability.MultiAlias, false},
-        {Credo.Check.Readability.Specs, []},
+        {Credo.Check.Readability.Specs, false},
         {Credo.Check.Readability.SinglePipe, false},
         {Credo.Check.Readability.WithCustomTaggedTuple, false},
         {Credo.Check.Refactor.ABCSize, false},

--- a/lib/membrane_live/webinars.ex
+++ b/lib/membrane_live/webinars.ex
@@ -9,36 +9,16 @@ defmodule MembraneLive.Webinars do
   alias MembraneLive.Webinars.Webinar
 
   @spec list_webinars :: list(Webinar.t())
-  def list_webinars do
-    Repo.all(Webinar)
-  end
+  def list_webinars, do: Repo.all(Webinar)
 
   @spec get_webinar(integer()) :: Webinar.t() | nil
   def get_webinar(id), do: Repo.get(Webinar, id)
 
-  @spec get_webinar!(integer()) :: Webinar.t()
+  @spec get_webinar!(integer()) :: {:ok, Webinar.t()}
   def get_webinar!(id), do: Repo.get!(Webinar, id)
-
-  @spec get_webinar_by_link(String.t()) :: Webinar.t() | nil
-  def get_webinar_by_link(link) do
-    get_webinar_by_link(link, :viewer_link)
-  end
-
-  defp get_webinar_by_link(link, :viewer_link) do
-    case Repo.get_by(Webinar, viewer_link: link) do
-      nil -> get_webinar_by_link(link, :moderator_link)
-      webinar -> webinar
-    end
-  end
-
-  defp get_webinar_by_link(link, :moderator_link) do
-    Repo.get_by(Webinar, moderator_link: link)
-  end
 
   @spec create_webinar(map) :: any
   def create_webinar(attrs \\ %{}) do
-    attrs = add_links(attrs)
-
     %Webinar{}
     |> Webinar.changeset(attrs)
     |> Repo.insert()
@@ -67,8 +47,14 @@ defmodule MembraneLive.Webinars do
     Webinar.changeset(webinar, attrs)
   end
 
-  defp add_links(attrs) do
-    attrs = Map.put(attrs, "viewer_link", "webinars/event/#{UUID.uuid4()}")
-    Map.put(attrs, "moderator_link", "webinars/event/#{UUID.uuid4()}")
+  @spec get_links(atom | %{:uuid => any, optional(any) => any}) :: %{
+          moderator_link: <<_::64, _::_*8>>,
+          viewer_link: <<_::64, _::_*8>>
+        }
+  def get_links(webinar) do
+    %{
+      viewer_link: "webinars/events/#{webinar.uuid}",
+      moderator_link: "webinars/events/#{webinar.uuid}/moderator"
+    }
   end
 end

--- a/lib/membrane_live/webinars/webinar.ex
+++ b/lib/membrane_live/webinars/webinar.ex
@@ -5,32 +5,29 @@ defmodule MembraneLive.Webinars.Webinar do
   use Ecto.Schema
   import Ecto.Changeset
 
+  @derive {Phoenix.Param, key: :uuid}
+  @primary_key {:uuid, :binary_id, autogenerate: true}
+
   @type t :: %__MODULE__{
           description: String.t(),
-          moderator_link: String.t(),
           presenters: list,
           start_date: NaiveDateTime.t(),
-          title: String.t(),
-          viewer_link: String.t()
+          title: String.t()
         }
 
   schema "webinars" do
     field(:description, :string)
-    field(:moderator_link, :string)
     field(:presenters, {:array, :string})
     field(:start_date, :naive_datetime)
     field(:title, :string)
-    field(:viewer_link, :string)
 
     timestamps()
   end
 
-  @spec changeset(t(), map()) :: Ecto.Changeset.t()
   @doc false
   def changeset(webinar, attrs) do
     webinar
-    |> cast(attrs, [:title, :start_date, :description, :presenters, :viewer_link, :moderator_link])
-    |> validate_required([:title, :start_date, :viewer_link, :moderator_link])
-    |> unique_constraint([:viewer_link, :moderator_link])
+    |> cast(attrs, [:title, :start_date, :description, :presenters])
+    |> validate_required([:title, :start_date])
   end
 end

--- a/lib/membrane_live_web.ex
+++ b/lib/membrane_live_web.ex
@@ -17,9 +17,6 @@ defmodule MembraneLiveWeb do
   and import those modules here.
   """
 
-  @spec controller ::
-          {:__block__, [],
-           [{:alias, [...], [...]} | {:import, [...], [...]} | {:use, [...], [...]}, ...]}
   def controller do
     quote do
       use Phoenix.Controller, namespace: MembraneLiveWeb
@@ -30,9 +27,6 @@ defmodule MembraneLiveWeb do
     end
   end
 
-  @spec view ::
-          {:__block__, [],
-           [{:__block__, [], [...]} | {:import, [...], [...]} | {:use, [...], [...]}, ...]}
   def view do
     quote do
       use Phoenix.View,
@@ -48,7 +42,6 @@ defmodule MembraneLiveWeb do
     end
   end
 
-  @spec live_view :: {:__block__, [], [{:__block__, [], [...]} | {:use, [...], [...]}, ...]}
   def live_view do
     quote do
       use Phoenix.LiveView,
@@ -58,7 +51,6 @@ defmodule MembraneLiveWeb do
     end
   end
 
-  @spec live_component :: {:__block__, [], [{:__block__, [], [...]} | {:use, [...], [...]}, ...]}
   def live_component do
     quote do
       use Phoenix.LiveComponent
@@ -67,7 +59,6 @@ defmodule MembraneLiveWeb do
     end
   end
 
-  @spec component :: {:__block__, [], [{:__block__, [], [...]} | {:use, [...], [...]}, ...]}
   def component do
     quote do
       use Phoenix.Component
@@ -76,7 +67,6 @@ defmodule MembraneLiveWeb do
     end
   end
 
-  @spec router :: {:__block__, [], [{:import, [...], [...]} | {:use, [...], [...]}, ...]}
   def router do
     quote do
       use Phoenix.Router
@@ -87,7 +77,6 @@ defmodule MembraneLiveWeb do
     end
   end
 
-  @spec channel :: {:__block__, [], [{:import, [...], [...]} | {:use, [...], [...]}, ...]}
   def channel do
     quote do
       use Phoenix.Channel
@@ -112,7 +101,6 @@ defmodule MembraneLiveWeb do
     end
   end
 
-  @spec __using__(atom) :: any
   @doc """
   When used, dispatch to the appropriate controller/view/etc.
   """

--- a/lib/membrane_live_web/controllers/webinar_controller.ex
+++ b/lib/membrane_live_web/controllers/webinar_controller.ex
@@ -18,7 +18,7 @@ defmodule MembraneLiveWeb.WebinarController do
       conn
       |> put_status(:created)
       |> put_resp_header("location", Routes.webinar_path(conn, :show, webinar))
-      |> render("show_links.json", webinar: webinar)
+      |> render("show_links.json", webinar_links: Webinars.get_links(webinar))
     end
   end
 
@@ -37,9 +37,9 @@ defmodule MembraneLiveWeb.WebinarController do
     get_with_callback(conn, params, &delete_callback/2)
   end
 
-  defp get_with_callback(conn, %{"id" => id} = params, callback) do
-    case Webinars.get_webinar(id) do
-      nil -> %{error: :not_found, message: "Webinar with id #{id} could not be found"}
+  defp get_with_callback(conn, %{"uuid" => uuid} = params, callback) do
+    case Webinars.get_webinar(uuid) do
+      nil -> %{error: :not_found, message: "Webinar with uuid #{uuid} could not be found"}
       webinar -> callback.(conn, Map.put(params, "webinar_db", webinar))
     end
   end

--- a/lib/membrane_live_web/router.ex
+++ b/lib/membrane_live_web/router.ex
@@ -18,7 +18,7 @@ defmodule MembraneLiveWeb.Router do
     pipe_through(:browser)
 
     get("/", PageController, :index)
-    resources("/webinars", WebinarController, except: [:edit, :new])
+    resources("/webinars", WebinarController, except: [:edit, :new], param: "uuid")
     get("/event/:param", PageController, :index)
   end
 

--- a/lib/membrane_live_web/views/webinar_view.ex
+++ b/lib/membrane_live_web/views/webinar_view.ex
@@ -12,26 +12,17 @@ defmodule MembraneLiveWeb.WebinarView do
     %{webinar: render_one(webinar, WebinarView, "webinar.json")}
   end
 
-  def render("show_links.json", %{webinar: webinar}) do
-    %{webinar_links: render_one(webinar, WebinarView, "webinar_links.json")}
+  def render("show_links.json", %{webinar_links: webinar_links}) do
+    %{webinar_links: webinar_links}
   end
 
   def render("webinar.json", %{webinar: webinar}) do
     %{
-      id: webinar.id,
+      uuid: webinar.uuid,
       title: webinar.title,
       start_date: webinar.start_date,
       description: webinar.description,
-      presenters: webinar.presenters,
-      viewer_link: webinar.viewer_link,
-      moderator_link: webinar.moderator_link
-    }
-  end
-
-  def render("webinar_links.json", %{webinar: webinar}) do
-    %{
-      viewer_link: webinar.viewer_link,
-      moderator_link: webinar.moderator_link
+      presenters: webinar.presenters
     }
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,8 @@ defmodule Membrane.Live.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      aliases: aliases(),
+      preferred_cli_env: [ci: :test],
 
       # hex
       description: "Membrane Live App",
@@ -59,7 +61,7 @@ defmodule Membrane.Live.Mixfile do
       {:plug_cowboy, "~> 2.5"},
       {:membrane_core, "~> 0.10.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:credo, ">= 0.0.0", only: :dev, runtime: false},
+      {:credo, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:uuid, "~> 1.1"}
     ]
   end
@@ -82,6 +84,17 @@ defmodule Membrane.Live.Mixfile do
       formatters: ["html"],
       source_ref: "v#{@version}",
       nest_modules_by_prefix: [Membrane.Template]
+    ]
+  end
+
+  def aliases do
+    [
+      ci: [
+        "format --check-formatted",
+        "compile --force --warnings-as-errors",
+        "test",
+        "credo"
+      ]
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -92,7 +92,7 @@ defmodule Membrane.Live.Mixfile do
       ci: [
         "format --check-formatted",
         "compile --force --warnings-as-errors",
-        "test",
+        "test --warnings-as-errors",
         "credo"
       ]
     ]

--- a/priv/repo/migrations/20220720111206_remove_links_from_database.exs
+++ b/priv/repo/migrations/20220720111206_remove_links_from_database.exs
@@ -1,0 +1,10 @@
+defmodule MembraneLive.Repo.Migrations.RemoveLinksFromDatabase do
+  use Ecto.Migration
+
+  def change do
+    alter table(:webinars) do
+      remove(:viewer_link)
+      remove(:moderator_link)
+    end
+  end
+end

--- a/priv/repo/migrations/20220720132255_changing_uuid_to_id.exs
+++ b/priv/repo/migrations/20220720132255_changing_uuid_to_id.exs
@@ -1,0 +1,10 @@
+defmodule MembraneLive.Repo.Migrations.ChangingUuidToId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:webinars) do
+      remove(:id)
+      add(:uuid, :binary_id)
+    end
+  end
+end

--- a/test/membrane_live/webinars_test.exs
+++ b/test/membrane_live/webinars_test.exs
@@ -10,11 +10,9 @@ defmodule MembraneLive.WebinarsTest do
 
     @invalid_attrs %{
       "description" => nil,
-      "moderator_link" => nil,
       "presenters" => nil,
       "start_date" => nil,
-      "title" => nil,
-      "viewer_link" => nil
+      "title" => nil
     }
 
     test "list_webinars/0 returns all webinars" do
@@ -24,7 +22,7 @@ defmodule MembraneLive.WebinarsTest do
 
     test "get_webinar!/1 returns the webinar with given id" do
       webinar = webinar_fixture()
-      assert Webinars.get_webinar!(webinar.id) == webinar
+      assert Webinars.get_webinar!(webinar.uuid) == webinar
     end
 
     test "create_webinar/1 with valid data creates a webinar" do
@@ -51,32 +49,28 @@ defmodule MembraneLive.WebinarsTest do
 
       update_attrs = %{
         "description" => "some updated description",
-        "moderator_link" => "some updated moderator_link",
         "presenters" => [],
         "start_date" => ~N[2022-07-18 10:20:00],
-        "title" => "some updated title",
-        "viewer_link" => "some updated viewer_link"
+        "title" => "some updated title"
       }
 
       assert {:ok, %Webinar{} = webinar} = Webinars.update_webinar(webinar, update_attrs)
       assert webinar.description == "some updated description"
-      assert webinar.moderator_link == "some updated moderator_link"
       assert webinar.presenters == []
       assert webinar.start_date == ~N[2022-07-18 10:20:00]
       assert webinar.title == "some updated title"
-      assert webinar.viewer_link == "some updated viewer_link"
     end
 
     test "update_webinar/2 with invalid data returns error changeset" do
       webinar = webinar_fixture()
       assert {:error, %Ecto.Changeset{}} = Webinars.update_webinar(webinar, @invalid_attrs)
-      assert webinar == Webinars.get_webinar!(webinar.id)
+      assert webinar == Webinars.get_webinar!(webinar.uuid)
     end
 
     test "delete_webinar/1 deletes the webinar" do
       webinar = webinar_fixture()
       assert {:ok, %Webinar{}} = Webinars.delete_webinar(webinar)
-      assert_raise Ecto.NoResultsError, fn -> Webinars.get_webinar!(webinar.id) end
+      assert_raise Ecto.NoResultsError, fn -> Webinars.get_webinar!(webinar.uuid) end
     end
 
     test "change_webinar/1 returns a webinar changeset" do

--- a/test/membrane_live_web/controllers/webinar_controller_test.exs
+++ b/test/membrane_live_web/controllers/webinar_controller_test.exs
@@ -25,6 +25,9 @@ defmodule MembraneLiveWeb.WebinarControllerTest do
     "title" => nil
   }
 
+  @link_prefix "webinars/events/"
+  @moderator_link_suffix "/moderator"
+
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
@@ -40,8 +43,13 @@ defmodule MembraneLiveWeb.WebinarControllerTest do
     test "renders webinar when data is valid", %{conn: conn} do
       conn = post(conn, Routes.webinar_path(conn, :create), webinar: @create_attrs)
 
-      assert %{"viewer_link" => viewer_link, "moderator_link" => _moderator_link} =
+      assert %{"viewer_link" => viewer_link, "moderator_link" => moderator_link} =
                json_response(conn, 201)["webinar_links"]
+
+      assert String.starts_with?(viewer_link, @link_prefix)
+      assert String.starts_with?(moderator_link, @link_prefix)
+
+      assert String.ends_with?(moderator_link, @moderator_link_suffix)
 
       uuid = get_uuid_from_link(viewer_link)
       webinar = Webinars.get_webinar(uuid)

--- a/test/membrane_live_web/controllers/webinar_controller_test.exs
+++ b/test/membrane_live_web/controllers/webinar_controller_test.exs
@@ -14,19 +14,15 @@ defmodule MembraneLiveWeb.WebinarControllerTest do
   }
   @update_attrs %{
     "description" => "some updated description",
-    "moderator_link" => "some updated moderator_link",
     "presenters" => [],
     "start_date" => ~N[2022-07-18 10:20:00],
-    "title" => "some updated title",
-    "viewer_link" => "some updated viewer_link"
+    "title" => "some updated title"
   }
   @invalid_attrs %{
     "description" => nil,
-    "moderator_link" => nil,
     "presenters" => nil,
     "start_date" => nil,
-    "title" => nil,
-    "viewer_link" => nil
+    "title" => nil
   }
 
   setup %{conn: conn} do
@@ -47,18 +43,16 @@ defmodule MembraneLiveWeb.WebinarControllerTest do
       assert %{"viewer_link" => viewer_link, "moderator_link" => moderator_link} =
                json_response(conn, 201)["webinar_links"]
 
-      webinar = Webinars.get_webinar_by_link(viewer_link)
-      id = webinar.id
+      uuid = get_uuid_from_link(viewer_link)
+      webinar = Webinars.get_webinar(uuid)
 
-      conn = get(conn, Routes.webinar_path(conn, :show, webinar.id))
+      conn = get(conn, Routes.webinar_path(conn, :show, webinar.uuid))
 
       assert %{
-               "id" => ^id,
+               "uuid" => ^uuid,
                "description" => "some description",
                "start_date" => "2022-07-17T10:20:00",
-               "title" => "some title",
-               "viewer_link" => ^viewer_link,
-               "moderator_link" => ^moderator_link
+               "title" => "some title"
              } = json_response(conn, 200)["webinar"]
     end
 
@@ -71,20 +65,21 @@ defmodule MembraneLiveWeb.WebinarControllerTest do
   describe "update webinar" do
     setup [:create_webinar]
 
-    test "renders webinar when data is valid", %{conn: conn, webinar: %Webinar{id: id} = webinar} do
+    test "renders webinar when data is valid", %{
+      conn: conn,
+      webinar: %Webinar{uuid: uuid} = webinar
+    } do
       conn = put(conn, Routes.webinar_path(conn, :update, webinar), webinar: @update_attrs)
-      assert %{"id" => ^id} = json_response(conn, 200)["webinar"]
+      assert %{"uuid" => ^uuid} = json_response(conn, 200)["webinar"]
 
-      conn = get(conn, Routes.webinar_path(conn, :show, id))
+      conn = get(conn, Routes.webinar_path(conn, :show, uuid))
 
       assert %{
-               "id" => ^id,
+               "uuid" => ^uuid,
                "description" => "some updated description",
-               "moderator_link" => "some updated moderator_link",
                "presenters" => [],
                "start_date" => "2022-07-18T10:20:00",
-               "title" => "some updated title",
-               "viewer_link" => "some updated viewer_link"
+               "title" => "some updated title"
              } = json_response(conn, 200)["webinar"]
     end
 
@@ -109,5 +104,9 @@ defmodule MembraneLiveWeb.WebinarControllerTest do
   defp create_webinar(_webinar) do
     webinar = webinar_fixture()
     %{webinar: webinar}
+  end
+
+  defp get_uuid_from_link(viewer_link) do
+    String.replace_prefix(viewer_link, "webinars/events/", "")
   end
 end

--- a/test/membrane_live_web/controllers/webinar_controller_test.exs
+++ b/test/membrane_live_web/controllers/webinar_controller_test.exs
@@ -40,7 +40,7 @@ defmodule MembraneLiveWeb.WebinarControllerTest do
     test "renders webinar when data is valid", %{conn: conn} do
       conn = post(conn, Routes.webinar_path(conn, :create), webinar: @create_attrs)
 
-      assert %{"viewer_link" => viewer_link, "moderator_link" => moderator_link} =
+      assert %{"viewer_link" => viewer_link, "moderator_link" => _moderator_link} =
                json_response(conn, 201)["webinar_links"]
 
       uuid = get_uuid_from_link(viewer_link)


### PR DESCRIPTION
Changes:
  - uuid as primary key in `webinars`
  - `GET webinars/:uuid ` response like the documentation
  - changes in credo - `@specs` are no longer checked
  - `alias` in `mix.ex`