### PR TITLE
LIVE-33: Add basic channel and presence tests

### DIFF
--- a/lib/membrane_live_web/channels/event_channel.ex
+++ b/lib/membrane_live_web/channels/event_channel.ex
@@ -32,7 +32,7 @@ defmodule MembraneLiveWeb.EventChannel do
   end
 
   def join(_topic, _params, _socket) do
-    {:error, %{reason: " This link is wrong."}}
+    {:error, %{reason: "This link is wrong."}}
   end
 
   def handle_info({:after_join, name}, socket) do

--- a/test/membrane_live_web/channels/event_channel_error_test.exs
+++ b/test/membrane_live_web/channels/event_channel_error_test.exs
@@ -6,8 +6,8 @@ defmodule MembraneLiveWeb.EventChannelErrorTest do
     return_value =
       MembraneLiveWeb.EventSocket
       |> socket("event_id", %{})
-      |> subscribe_and_join(MembraneLiveWeb.EventChannel, "event:teneventnieistnieje", %{
-        name: "Andrzej"
+      |> subscribe_and_join(MembraneLiveWeb.EventChannel, "event:invalid_event_id", %{
+        name: "John"
       })
 
     assert return_value == {:error, %{reason: "This link is wrong."}}
@@ -25,10 +25,10 @@ defmodule MembraneLiveWeb.EventChannelErrorTest do
     socket = MembraneLiveWeb.EventSocket |> socket("event_id", %{})
 
     {:ok, _reply, socket} =
-      subscribe_and_join(socket, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{name: "Andrzej"})
+      subscribe_and_join(socket, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{name: "John"})
 
     return_value =
-      subscribe_and_join(socket, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{name: "Andrzej"})
+      subscribe_and_join(socket, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{name: "John"})
 
     assert return_value == {:error, %{reason: "Viewer with this name already exists."}}
   end

--- a/test/membrane_live_web/channels/event_channel_error_test.exs
+++ b/test/membrane_live_web/channels/event_channel_error_test.exs
@@ -1,0 +1,35 @@
+defmodule MembraneLiveWeb.EventChannelErrorTest do
+  use MembraneLiveWeb.ChannelCase
+  alias MembraneLive.{Repo, Webinars.Webinar}
+
+  test "join to nonexistent webinar" do
+    return_value =
+      MembraneLiveWeb.EventSocket
+      |> socket("event_id", %{})
+      |> subscribe_and_join(MembraneLiveWeb.EventChannel, "event:teneventnieistnieje", %{
+        name: "Andrzej"
+      })
+
+    assert return_value == {:error, %{reason: "This link is wrong."}}
+  end
+
+  test "join to webinar with user with the same name" do
+    {:ok, %{uuid: uuid}} =
+      Repo.insert(%Webinar{
+        description: "a",
+        presenters: [],
+        start_date: ~N[2019-10-31 23:00:07],
+        title: "Test webinar"
+      })
+
+    socket = MembraneLiveWeb.EventSocket |> socket("event_id", %{})
+
+    {:ok, _reply, socket} =
+      subscribe_and_join(socket, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{name: "Andrzej"})
+
+    return_value =
+      subscribe_and_join(socket, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{name: "Andrzej"})
+
+    assert return_value == {:error, %{reason: "Viewer with this name already exists."}}
+  end
+end

--- a/test/membrane_live_web/channels/event_channel_test.exs
+++ b/test/membrane_live_web/channels/event_channel_test.exs
@@ -21,19 +21,20 @@ defmodule MembraneLiveWeb.EventChannelTest do
 
     {:ok, _reply, socket1} =
       subscribe_and_join(socket1, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{
-        name: "Andrzej"
+        name: "John"
       })
 
     {:ok, _reply, socket2} =
-      subscribe_and_join(socket2, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{name: "Janusz"})
+      subscribe_and_join(socket2, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{name: "Adam"})
 
-    assert %{"Andrzej" => %{}, "Janusz" => %{}} = Presence.list("event:#{uuid}")
+    pres = Presence.list("event:#{uuid}")
+    assert is_map_key(pres, "John") and is_map_key(pres, "Adam")
 
     Process.unlink(socket1.channel_pid)
     close(socket1)
 
     pres = Presence.list("event:#{uuid}")
-    assert is_map_key(pres, "Janusz") && !is_map_key(pres, "Andrzej")
+    assert is_map_key(pres, "Adam") and not is_map_key(pres, "John")
 
     Process.unlink(socket2.channel_pid)
     close(socket2)

--- a/test/membrane_live_web/channels/event_channel_test.exs
+++ b/test/membrane_live_web/channels/event_channel_test.exs
@@ -1,0 +1,43 @@
+defmodule MembraneLiveWeb.EventChannelTest do
+  use MembraneLiveWeb.ChannelCase
+  alias MembraneLive.{Repo, Webinars.Webinar}
+  alias MembraneLiveWeb.Presence
+
+  setup do
+    {:ok, %{uuid: uuid}} =
+      Repo.insert(%Webinar{
+        description: "a",
+        presenters: [],
+        start_date: ~N[2019-10-31 23:00:07],
+        title: "Test webinar"
+      })
+
+    %{uuid: uuid}
+  end
+
+  test "check if users are in presence", %{uuid: uuid} do
+    socket1 = MembraneLiveWeb.EventSocket |> socket("event_id1", %{})
+    socket2 = MembraneLiveWeb.EventSocket |> socket("event_id2", %{})
+
+    {:ok, _reply, socket1} =
+      subscribe_and_join(socket1, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{
+        name: "Andrzej"
+      })
+
+    {:ok, _reply, socket2} =
+      subscribe_and_join(socket2, MembraneLiveWeb.EventChannel, "event:#{uuid}", %{name: "Janusz"})
+
+    assert %{"Andrzej" => %{}, "Janusz" => %{}} = Presence.list("event:#{uuid}")
+
+    Process.unlink(socket1.channel_pid)
+    close(socket1)
+
+    pres = Presence.list("event:#{uuid}")
+    assert is_map_key(pres, "Janusz") && !is_map_key(pres, "Andrzej")
+
+    Process.unlink(socket2.channel_pid)
+    close(socket2)
+
+    assert Presence.list("event:#{uuid}") == %{}
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,0 +1,35 @@
+defmodule MembraneLiveWeb.ChannelCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  channel tests.
+
+  Such tests rely on `Phoenix.ChannelTest` and also
+  import other functionality to make it easier
+  to build common data structures and query the data layer.
+
+  Finally, if the test case interacts with the database,
+  we enable the SQL sandbox, so changes done to the database
+  are reverted at the end of every test. If you are using
+  PostgreSQL, you can even run database tests asynchronously
+  by setting `use MembraneLiveWeb.ChannelCase, async: true`, although
+  this option is not recommended for other databases.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with channels
+      import Phoenix.ChannelTest
+      import MembraneLiveWeb.ChannelCase
+
+      # The default endpoint for testing
+      @endpoint MembraneLiveWeb.Endpoint
+    end
+  end
+
+  setup tags do
+    MembraneLive.DataCase.setup_sandbox(tags)
+    :ok
+  end
+end


### PR DESCRIPTION
Add basic channel and presence tests. At this point there's not much to test because the custom channel functionality have not been implemented yet.