### PR TITLE
LIVE-96: Refactor canvas and screensharing

### DIFF
--- a/assets/js/components/ControlPanel.tsx
+++ b/assets/js/components/ControlPanel.tsx
@@ -30,12 +30,12 @@ import {
   shareScreen,
   changeSource,
   changeTrackIsEnabled,
-  findTrackByType,
   getCurrentDeviceName,
   getSources,
   Sources,
   SourceType,
   stopShareScreen,
+  checkTrackIsEnabled,
 } from "../utils/rtcUtils";
 import { Mode } from "./StreamArea";
 import { getFontColor } from "../utils/styleUtils";
@@ -189,7 +189,7 @@ const ControlPanel = ({
     return (
       <GenericButton
         icon={
-          findTrackByType(clientName, sourceType)?.enabled ? (
+          checkTrackIsEnabled(clientName, sourceType) ? (
             <IconEnabled className="PanelButton Enabled" />
           ) : (
             <IconDisabled className="PanelButton Disabled" />

--- a/assets/js/components/ControlPanel.tsx
+++ b/assets/js/components/ControlPanel.tsx
@@ -179,7 +179,6 @@ const ControlPanel = ({
         onSelectSource={(deviceId) => {
           changeSource(webrtc, clientName, deviceId, sourceType, playerCallback).then(() => {
             rerender();
-            setSharingScreen(false);
           });
         }}
       />

--- a/assets/js/utils/canvasUtils.ts
+++ b/assets/js/utils/canvasUtils.ts
@@ -5,14 +5,10 @@ export const getMergedTracks = async (
   mergedScreenRef: MergedScreenRef,
   presenterStream: MediaStream
 ) => {
-  mergedScreenRef.refreshId && stopRefreshingAndRemovePreviousScreen(mergedScreenRef);
-
   const screenStream: MediaStream = await navigator.mediaDevices.getDisplayMedia(
     SCREEN_CONSTRAINTS
   );
-  const cameraStream: MediaStream = new MediaStream(
-    mergedScreenRef.cameraTrack ? [mergedScreenRef.cameraTrack] : presenterStream.getVideoTracks()
-  ).clone();
+  const cameraStream: MediaStream = new MediaStream(presenterStream.getVideoTracks()).clone();
 
   mergedScreenRef.screenTrack = screenStream.getVideoTracks().pop();
   mergedScreenRef.cameraTrack = cameraStream.getVideoTracks().pop();
@@ -68,13 +64,6 @@ const makeComposite = async (
   mergedScreenRef.refreshId = requestVideoFrame(() =>
     makeComposite(canvasElement, canvasCtx, camera, screen, mergedScreenRef)
   );
-};
-
-const stopRefreshingAndRemovePreviousScreen = (mergedScreenRef: MergedScreenRef): void => {
-  mergedScreenRef.screenTrack?.stop();
-  mergedScreenRef.screenTrack = undefined;
-  clearTimeout(mergedScreenRef.refreshId);
-  mergedScreenRef.refreshId = undefined;
 };
 
 const requestVideoFrame = (callback: Function) => {

--- a/assets/js/utils/canvasUtils.ts
+++ b/assets/js/utils/canvasUtils.ts
@@ -5,9 +5,12 @@ export const getMergedTracks = async (
   mergedScreenRef: MergedScreenRef,
   presenterStream: MediaStream
 ) => {
-  const screenStream: MediaStream = await navigator.mediaDevices.getDisplayMedia(
-    SCREEN_CONSTRAINTS
-  );
+  mergedScreenRef.refreshId && stopRefreshingAndRemovePreviousScreen(mergedScreenRef);
+
+  const screenStream: MediaStream = mergedScreenRef.screenTrack
+    ? new MediaStream([mergedScreenRef.screenTrack])
+    : await navigator.mediaDevices.getDisplayMedia(SCREEN_CONSTRAINTS);
+
   const cameraStream: MediaStream = new MediaStream(presenterStream.getVideoTracks()).clone();
 
   mergedScreenRef.screenTrack = screenStream.getVideoTracks().pop();
@@ -64,6 +67,11 @@ const makeComposite = async (
   mergedScreenRef.refreshId = requestVideoFrame(() =>
     makeComposite(canvasElement, canvasCtx, camera, screen, mergedScreenRef)
   );
+};
+
+const stopRefreshingAndRemovePreviousScreen = (mergedScreenRef: MergedScreenRef): void => {
+  clearTimeout(mergedScreenRef.refreshId);
+  mergedScreenRef.refreshId = undefined;
 };
 
 const requestVideoFrame = (callback: Function) => {

--- a/assets/js/utils/rtcUtils.ts
+++ b/assets/js/utils/rtcUtils.ts
@@ -158,12 +158,12 @@ export const changeSource = async (
   playerCallback: (sourceType: SourceType) => void
 ) => {
   await setSourceById(clientName, deviceId, sourceType, playerCallback);
+  if (!webrtc) return;
   if (mergedScreenRef.refreshId && sourceType == "video") {
-    if (!webrtc) return;
     shareScreen(webrtc, clientName, playerCallback);
   } else {
     const newTrack = findTrackByType(clientName, sourceType);
-    if (!webrtc || !newTrack) return;
+    if (!newTrack) return;
     if (sourceIds[sourceType]) webrtc.replaceTrack(sourceIds[sourceType], newTrack);
     else sourceIds[sourceType] = webrtc.addTrack(newTrack, presenterStreams[clientName]);
   }

--- a/assets/js/utils/rtcUtils.ts
+++ b/assets/js/utils/rtcUtils.ts
@@ -30,8 +30,19 @@ export const findTrackByType = (name: string, sourceType: SourceType) => {
 };
 
 export const changeTrackIsEnabled = (name: string, sourceType: SourceType) => {
-  const track = findTrackByType(name, sourceType);
+  const track =
+    sourceType == "video" && mergedScreenRef.cameraTrack
+      ? mergedScreenRef.cameraTrack
+      : findTrackByType(name, sourceType);
   if (track) track.enabled = !track.enabled;
+};
+
+export const checkTrackIsEnabled = (name: string, sourceType: SourceType) => {
+  const track =
+    sourceType == "video" && mergedScreenRef.cameraTrack
+      ? mergedScreenRef.cameraTrack
+      : findTrackByType(name, sourceType);
+  return track?.enabled;
 };
 
 export const getCurrentDeviceName = (clientName: string, sourceType: SourceType) => {


### PR DESCRIPTION
Refactor canvas and screensharing:
- remove unnecessary canvas functionality
- make turning off camera to hide only presenter box in canvas, not whole screen
- make changing video device not turn off screensharing