### PR TITLE
removing ./scripts from mix setup

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -116,7 +116,7 @@ defmodule Membrane.Live.Mixfile do
         "test --warnings-as-errors",
         "credo"
       ],
-      setup: ["deps.get", "cmd --cd assets npm ci", "cmd ./scripts/key-gen.sh"],
+      setup: ["deps.get", "cmd --cd assets npm ci"],
       "assets.deploy": [
         "esbuild default --minify",
         "phx.digest"


### PR DESCRIPTION
After talking with Piotrek we came to the assumption that script should be deleted from the `mix setup` commands list. This is because the script is not necessary for building the project. This way we don't need to change the dockerfile 🐳