### PR TITLE
Fixing taking refresh token instead of auth token

### DIFF
--- a/assets/js/services/index.tsx
+++ b/assets/js/services/index.tsx
@@ -1,5 +1,5 @@
 import * as JwtApi from "./jwtApi";
-import { storageGetAuthToken, storageSetJwt } from "../utils/storageUtils";
+import { storageGetRefreshToken, storageSetJwt } from "../utils/storageUtils";
 
 const axios = require("axios").default;
 
@@ -26,7 +26,7 @@ axiosWithInterceptor.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    const refreshToken = storageGetAuthToken();
+    const refreshToken = storageGetRefreshToken();
     try {
       const response = await axios.post("/auth/refresh", { refreshToken });
       storageSetJwt(response.data);


### PR DESCRIPTION
There was an error in the interceptor. Auth token was assigned to the refresh token. The corrections have been made.