### PR TITLE
Deleting ensure_repo_created

### DIFF
--- a/lib/membrane_live/release.ex
+++ b/lib/membrane_live/release.ex
@@ -6,12 +6,10 @@ defmodule MembraneLive.Release do
     load_app()
 
     for repo <- repos() do
-      with :ok <- ensure_repo_created(repo),
-           {:ok, _, _} <- Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true)) do
-        :ok
-      else
-        error -> raise "DB problem: #{error}"
-      end
+      {:ok, _fun_return, _apps} =
+        Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+
+      :ok
     end
   end
 
@@ -37,13 +35,5 @@ defmodule MembraneLive.Release do
 
   defp load_app do
     Application.load(@app)
-  end
-
-  defp ensure_repo_created(repo) do
-    case repo.__adapter__.storage_up(repo.config) do
-      :ok -> :ok
-      {:error, :already_up} -> :ok
-      {:error, term} -> {:error, term}
-    end
   end
 end


### PR DESCRIPTION
Deleting `ensure_repo_created()` from `release.ex`.
I've talked to Piotrek and he has said this change seems to be ok.