### PR TITLE
Fixed presenter joining WebRTC without any tracks.

### DIFF
--- a/assets/js/components/event/PresenterArea.tsx
+++ b/assets/js/components/event/PresenterArea.tsx
@@ -133,6 +133,9 @@ const PresenterArea = ({ client, privateChannel, eventChannel, mode, setMode }: 
     );
   };
 
+  const isStartPresentingButtonVisible =
+    clientStatus === "idle" && peersState.peers[client.email]?.stream.getTracks().length > 0;
+
   return clientStatus != "not_presenter" ? (
     <div className={`PresenterArea ${mode == "hls" ? "Hidden" : ""}`}>
       {clientStatus === "connected" ? (
@@ -158,7 +161,7 @@ const PresenterArea = ({ client, privateChannel, eventChannel, mode, setMode }: 
           rerender={rerender}
         />
       )}
-      {clientStatus === "idle" && (
+      {isStartPresentingButtonVisible && (
         <button className="StartPresentingButton" onClick={onPresenterReady}>
           Start presenting
         </button>


### PR DESCRIPTION
Fixed issue with presenter joining without any tracks connected.
That happened when we joined immediately after becoming a presenter. Connecting tracks takes some time and if we joined before that it caused the peer to join without audio or video tracks and made the engine crash.