### PR TITLE
Changing mobile sidebar position

### DIFF
--- a/assets/css/event/mobilesidebars.css
+++ b/assets/css/event/mobilesidebars.css
@@ -1,8 +1,8 @@
 .MobileRightSidebar {
   position: absolute;
-  bottom: 2rem;
+  bottom: 50%;
   right: 0;
-  height: 100%;
+  transform: translate(0, 50%);
 
   display: flex;
   flex-direction: column;
@@ -38,7 +38,6 @@
 @media screen and (max-height: 500px) {
   .MobileRightSidebar {
     gap: 0.5rem;
-    bottom: 7rem;
   }
 
   .MobileRightSidebarButton {

--- a/assets/js/components/event/HlsPlayer.tsx
+++ b/assets/js/components/event/HlsPlayer.tsx
@@ -5,16 +5,20 @@ import HlsControlBar from "./HlsControlBar";
 import { Channel } from "phoenix";
 import { MediaController } from "media-chrome/dist/react";
 import { ScreenTypeContext } from "../../utils/ScreenTypeContext";
+import { MobileRightSidebar } from "./MobileRightSidebar";
+import { CardStatus } from "../../types/types";
+
 import "../../../css/event/hlsplayer.css";
 
 type HlsPlayerProps = {
   attachVideo: (videoElem: HTMLVideoElement | null) => void;
   addMessage: ((offset: number) => void) | undefined;
   presenterName: string | undefined;
+  setCard: React.Dispatch<React.SetStateAction<CardStatus>>;
   eventChannel?: Channel | undefined;
 };
 
-const HlsPlayer = ({ attachVideo, addMessage, presenterName, eventChannel }: HlsPlayerProps) => {
+const HlsPlayer = ({ attachVideo, addMessage, presenterName, setCard, eventChannel }: HlsPlayerProps) => {
   const screenType = useContext(ScreenTypeContext);
   const playerRef = useRef<HTMLVideoElement>(null);
 
@@ -58,6 +62,7 @@ const HlsPlayer = ({ attachVideo, addMessage, presenterName, eventChannel }: Hls
           </div>
         )}
         {eventChannel && <HeartAnimation eventChannel={eventChannel} />}
+        {screenType.device === "mobile" && <MobileRightSidebar setCard={setCard} />}
       </div>
     </div>
   );

--- a/assets/js/components/event/HlsPlayer.tsx
+++ b/assets/js/components/event/HlsPlayer.tsx
@@ -14,13 +14,15 @@ type HlsPlayerProps = {
   attachVideo: (videoElem: HTMLVideoElement | null) => void;
   addMessage: ((offset: number) => void) | undefined;
   presenterName: string | undefined;
-  setCard: React.Dispatch<React.SetStateAction<CardStatus>>;
   eventChannel?: Channel | undefined;
+  setCard?: React.Dispatch<React.SetStateAction<CardStatus>>;
 };
 
-const HlsPlayer = ({ attachVideo, addMessage, presenterName, setCard, eventChannel }: HlsPlayerProps) => {
+const HlsPlayer = ({ attachVideo, addMessage, presenterName, eventChannel, setCard }: HlsPlayerProps) => {
   const screenType = useContext(ScreenTypeContext);
   const playerRef = useRef<HTMLVideoElement>(null);
+
+  const showMobileSideBar = screenType.device === "mobile" && setCard;
 
   useEffect(() => {
     attachVideo(playerRef.current);
@@ -62,7 +64,7 @@ const HlsPlayer = ({ attachVideo, addMessage, presenterName, setCard, eventChann
           </div>
         )}
         {eventChannel && <HeartAnimation eventChannel={eventChannel} />}
-        {screenType.device === "mobile" && <MobileRightSidebar setCard={setCard} />}
+        {showMobileSideBar && <MobileRightSidebar setCard={setCard} />}
       </div>
     </div>
   );

--- a/assets/js/components/event/StreamArea.tsx
+++ b/assets/js/components/event/StreamArea.tsx
@@ -92,7 +92,7 @@ const StreamArea = ({
                   addMessage={undefined}
                   setCard={setCard}
                 />
-                {device == "mobile" && (
+                {device === "mobile" && (
                   <MobileHlsBar
                     client={client}
                     eventTitle={eventTitle}

--- a/assets/js/components/event/StreamArea.tsx
+++ b/assets/js/components/event/StreamArea.tsx
@@ -7,10 +7,13 @@ import { ScreenTypeContext } from "../../utils/ScreenTypeContext";
 import { RotateLeft } from "react-swm-icon-pack";
 import { switchAskingForBeingPresenter } from "../../utils/channelUtils";
 import MobileHlsBar from "./MobileHlsBar";
-import type { Mode, Client, Product, ChatMessage, CardStatus } from "../../types/types";
 import { MobileRightSidebar } from "./MobileRightSidebar";
 import { MobileBottomPanel } from "./MobileBottomPanel";
 import { useAutoHideMobileBottomBar } from "../../utils/useAutoHideMobileBottomBar";
+import type { Mode, Client, PlaylistPlayableMessage, Product, ChatMessage, CardStatus } from "../../types/types";
+import { useStartStream } from "../../utils/StreamStartContext";
+import { config } from "../../utils/const";
+import { useAutoHideMobileBottomBar } from "./useAutoHideMobileBottomBar";
 
 import "../../../css/event/streamarea.css";
 
@@ -87,18 +90,16 @@ const StreamArea = ({
                   presenterName={presenterName}
                   eventChannel={eventChannel}
                   addMessage={undefined}
+                  setCard={setCard}
                 />
-                {device === "mobile" && (
-                  <>
-                    <MobileRightSidebar setCard={setCard} />
-                    <MobileHlsBar
-                      client={client}
-                      eventTitle={eventTitle}
-                      amIPresenter={amIPresenter}
-                      setMode={setMode}
-                      switchAsking={switchAsking}
-                    />
-                  </>
+                {device == "mobile" && (
+                  <MobileHlsBar
+                    client={client}
+                    eventTitle={eventTitle}
+                    amIPresenter={amIPresenter}
+                    setMode={setMode}
+                    switchAsking={switchAsking}
+                  />
                 )}
               </>
             ) : (

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,7 +1,7 @@
 import Config
 
 config :membrane_live, MembraneLiveWeb.Endpoint,
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {0, 0, 0, 0}, port: 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,


### PR DESCRIPTION
The mobile right sidebar has overlayed the fullscreen icon. I've fixed that by restyling the component and moving it more into the sidebar.

<img width="351" alt="Screenshot 2023-01-13 at 10 53 26" src="https://user-images.githubusercontent.com/58188916/212291668-4b500108-21be-4d18-aae8-2a779e96c6fe.png">
